### PR TITLE
Update AstartesWeapons.ts

### DIFF
--- a/src/data/factions/astartes/AstartesWeapons.ts
+++ b/src/data/factions/astartes/AstartesWeapons.ts
@@ -32,7 +32,7 @@ export const MarineCombatKnife: Weapon = {
     {
       types: [Combat],
       attack: 3,
-      dam: 2,
+      dam: 3,
       ap: 0,
       special: [Only('Space Marines and Scouts')],
     },


### PR DESCRIPTION
Added 1 Damage to Marine Knife. (The intention is that they can have a free combat weapon that's better than non-marines to represent their strength.)